### PR TITLE
[feat] add umd build version, close #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "main": "./lib/index",
   "files": [
-    "lib"
+    "lib",
+    "dist"
   ],
   "scripts": {
     "compile": "rm -rf lib && babel src --out-dir lib",
@@ -35,7 +36,7 @@
     "doc": "atool-doc",
     "doc-build": "atool-doc --build",
     "gh-pages": "atool-doc --build && gh-pages -d __site",
-    "pub": "npm run compile && npm publish"
+    "pub": "npm run compile && npm run build && npm publish"
   },
   "peerDependencies": {
     "g2": "^1.2.6"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,18 @@ const webpack = require('atool-build/lib/webpack');
 module.exports = function(config) {
   return Object.assign({}, config, {
     externals: {
-      g2: 'G2',
-      react: 'React',
+      g2: {
+        root: 'G2',
+        commonjs2: 'g2',
+        commonjs: 'g2',
+        amd: 'g2',
+      },
+      react: {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react',
+      },
     },
     output: Object.assign({}, config.output, {
       library: 'createG2',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,15 @@
+const webpack = require('atool-build/lib/webpack');
+
+module.exports = function(config) {
+  return Object.assign({}, config, {
+    externals: {
+      g2: 'G2',
+      react: 'React',
+    },
+    output: Object.assign({}, config.output, {
+      library: 'createG2',
+      libraryTarget: 'umd',
+    }),
+    plugins: config.plugins.filter(i => !(i instanceof webpack.optimize.CommonsChunkPlugin)),
+  });
+};


### PR DESCRIPTION
@afc163

这种 peerDeps 的怎么处理好一些？比如 g2-react 依赖的 g2，现在 externals 是写死的 `G2`

但是如果用户不起这个名字就会有问题了
