### PR TITLE
__operation bind this

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "g2-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "factory wrapper for g2",
   "keywords": [
     "react",

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ export default function createG2(__operation) {
         forceFit,
       });
       chart.source(data);
-      __operation(chart);
+      __operation.bind(this)(chart);
       this.chart = chart;
     }
 


### PR DESCRIPTION
现在如果用g2-react去封装组件的话，在__operation拿不到组件相关的任何东西，起码把当前组件的this传入一下，这样可以访问到一些额外的props，另外是不是可以把依赖的g2版本升级一下
