### PR TITLE
修复初始数据为空时，改变数据无法正确重新渲染的问题

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ export default function createG2(__operation) {
 
     componentWillUnmount() {
       this.destroyChart();
+      this.chartId = null;
     }
 
     initChart(props) {
@@ -67,7 +68,6 @@ export default function createG2(__operation) {
         this.chart.destroy();
       }
       this.chart = null;
-      this.chartId = null;
     }
 
     render() {

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,12 @@ export default function createG2(__operation) {
       const { data: newData, width: newWidth, height: newHeight, plotCfg: newPlotCfg } = newProps;
       const { data: oldData, width: oldWidth, height: oldHeight, plotCfg: oldPlotCfg } = this.props;
 
+      if (oldData.length === 0 && newData.length > 0) {
+        this.destroyChart();
+        this.initChart(newProps);
+        return;
+      }
+
       if (newPlotCfg !== oldPlotCfg) {
         console.warn('plotCfg 不支持修改');
       }
@@ -40,9 +46,7 @@ export default function createG2(__operation) {
     }
 
     componentWillUnmount() {
-      this.chart.destroy();
-      this.chart = null;
-      this.chartId = null;
+      this.destroyChart();
     }
 
     initChart(props) {
@@ -56,6 +60,14 @@ export default function createG2(__operation) {
       chart.source(data);
       __operation(chart);
       this.chart = chart;
+    }
+
+    destroyChart() {
+      if (this.chart) {
+        this.chart.destroy();
+      }
+      this.chart = null;
+      this.chartId = null;
     }
 
     render() {


### PR DESCRIPTION
其实这个应该是 g2 的问题
[这里是 fix 以后的效果](https://means88.github.io/g2-react/examples/line.html)

问题重现：
[从这里稍加修改的一个示例](https://antv.alipay.com/g2/demo/02-line/simple-line.html)
```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <title>简单线图</title>
    <script src="https://a.alipayobjects.com/jquery/jquery/1.11.1/jquery.js"></script>
    <script src="https://a.alipayobjects.com/g/datavis/g2/2.2.6/g2.js"></script>
  </head>
  <body>
    <div id="c1"></div>
    <div id="button"></div>
    <script>
      var data = [];
      // ***** 加上这里 *****
      var newData = [
        {month: 'Jan', temperature: 7.0},
        {month: 'Feb', temperature: 6.9},
        {month: 'Mar', temperature: 9.5},
        {month: 'Apr', temperature: 14.5},
        {month: 'May', temperature: 18.2},
        {month: 'Jun', temperature: 21.5},
        {month: 'Jul', temperature: 25.2},
        {month: 'Aug', temperature: 26.5},
        {month: 'Sep', temperature: 23.3},
        {month: 'Oct', temperature: 18.3},
        {month: 'Nov', temperature: 13.9},
        {month: 'Dec', temperature: 9.6}
      ];
      var chart = new G2.Chart({
        id: 'c1',
        forceFit: true,
        height: 450
      });
      chart.source(data, {
        month: {
          alias: '月份',
          range: [0, 1]
        },
        temperature: {
          alias: '平均温度(°C)'
        }
      });
      chart.line().position('month*temperature').size(2);
      chart.render();
      // ***** 改变数据 *****
      chart.changeData(newData);
    </script>
  </body>
</html>
```
改变数据后的效果是这样的 
![image](https://cloud.githubusercontent.com/assets/5810331/24396731/c8758708-13d6-11e7-93e1-5738261a3f3f.png)
